### PR TITLE
[WEB-PLP-10]. Changed links in breadcrumbs to anchor tags

### DIFF
--- a/react/components/BaseBreadcrumb.tsx
+++ b/react/components/BaseBreadcrumb.tsx
@@ -1,9 +1,12 @@
 import React, { Fragment, useMemo } from "react";
 import unorm from "unorm";
-import { Link, useRuntime } from "vtex.render-runtime";
+import { useRuntime } from "vtex.render-runtime";
 import { useSearchPage } from "vtex.search-page-context/SearchPageContext";
 import { useCssHandles, applyModifiers } from "vtex.css-handles";
 import { useDevice } from "vtex.device-detector";
+import HeadlessLink from "./HeadlessLink";
+
+
 
 const CSS_HANDLES = [
   "container",
@@ -57,6 +60,8 @@ const getCategoriesList = (categories: string[]): NavigationItem[] => {
   });
 };
 
+
+
 /**
  * Breadcrumb Component.
  */
@@ -94,13 +99,12 @@ const Breadcrumb: React.FC<Props> = ({
   return (
     <div data-testid="breadcrumb" className={`${handles.container} pv3`}>
       {/* The "home page" option on the breadcrumbs  */}
-      <Link
+      <HeadlessLink
         className={`${handles.link} ${handles.homeLink} ${linkBaseClasses} v-mid`}
-        page="store.home"
+        href="/"
       >
         Home
-      </Link>
-
+      </HeadlessLink>
       {isCollection ? (
         <span
           key={`navigation-item-${1}`}
@@ -110,17 +114,15 @@ const Breadcrumb: React.FC<Props> = ({
           )} ph2 c-muted-2`}
         >
           /
-          <Link
+          <HeadlessLink
             className={`${applyModifiers(
               handles.link,
               (1).toString()
             )} ${linkBaseClasses}`}
-            to={path}
-            // See https://github.com/vtex-apps/breadcrumb/pull/66 for the reasoning behind this
-            waitToPrefetch={1200}
+            href={path}
           >
             {"Shop the Collection"}
-          </Link>
+          </HeadlessLink>
         </span>
       ) : (
         navigationList.map(({ name, href }, i) => {
@@ -141,17 +143,15 @@ const Breadcrumb: React.FC<Props> = ({
               )} ph2 c-muted-2`}
             >
               /
-              <Link
+              <HeadlessLink
                 className={`${applyModifiers(
                   handles.link,
                   (i + 1).toString()
                 )} ${linkBaseClasses}`}
-                to={isCollection ? path : href}
-                // See https://github.com/vtex-apps/breadcrumb/pull/66 for the reasoning behind this
-                waitToPrefetch={1200}
+                href={isCollection ? path : href}
               >
                 {isCollection ? "Shop the Collection" : decodedName}
-              </Link>
+              </HeadlessLink>
             </span>
           );
         })

--- a/react/components/HeadlessLink.tsx
+++ b/react/components/HeadlessLink.tsx
@@ -1,26 +1,28 @@
-import React from 'react'
-import HeadlessLoadingBar from './HeadlessLoadingBar'
+import React from 'react';
+import HeadlessLoadingBar from './HeadlessLoadingBar';
 
 type IProps = {
-    children: React.ReactNode
-    className?: string
-    onClick?: () => void
-    href?: string
-}
-function HeadlessLink(props: IProps) {
-	const [showLoadingBar, setShowLoadingBar] = React.useState(false);
+  children: React.ReactNode;
+  className?: string;
+  onClick?: () => void;
+  href?: string;
+};
 
-	const handleClick = () => {
-		setShowLoadingBar(true)
+function HeadlessLink(props: IProps) {
+  const [showLoadingBar, setShowLoadingBar] = React.useState(false);
+
+  const handleClick = () => {
+    setShowLoadingBar(true);
   };
 
   return (
     <>
-     {showLoadingBar && <HeadlessLoadingBar /> } 
-     	<a href={props.href} onClick={handleClick} className={props.className}>{props.children}</a>
+      {showLoadingBar && <HeadlessLoadingBar />}
+      <a href={props.href} onClick={handleClick} className={props.className}>
+        {props.children}
+      </a>
     </>
-   
-  )
+  );
 }
 
-export default HeadlessLink
+export default HeadlessLink;

--- a/react/components/HeadlessLink.tsx
+++ b/react/components/HeadlessLink.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import HeadlessLoadingBar from './HeadlessLoadingBar'
+
+type IProps = {
+    children: React.ReactNode
+    className?: string
+    onClick?: () => void
+    href?: string
+}
+function HeadlessLink(props: IProps) {
+	const [showLoadingBar, setShowLoadingBar] = React.useState(false);
+
+	const handleClick = () => {
+		setShowLoadingBar(true)
+  };
+
+  return (
+    <>
+     {showLoadingBar && <HeadlessLoadingBar /> } 
+     	<a href={props.href} onClick={handleClick} className={props.className}>{props.children}</a>
+    </>
+   
+  )
+}
+
+export default HeadlessLink

--- a/react/components/HeadlessLoadingBar.tsx
+++ b/react/components/HeadlessLoadingBar.tsx
@@ -3,23 +3,23 @@ import { useCssHandles } from "vtex.css-handles";
 const CSS_HANDLES = ['HeadlessLoadingBar'] as const;
 
 const HeadlessLoadingBar = () => {
-const handles = useCssHandles(CSS_HANDLES);
+  const handles = useCssHandles(CSS_HANDLES);
 
-	return (
-		<div
-			className={`${handles.HeadlessLoadingBar} fixed top-0 left-0 right-0 z-max bg-action-primary`}
-			style={{ height: 4 }}
-		>
-			<div
-				style={{
-					background:
-					'background: linear-gradient(90deg, rgba(255, 255, 255, 0.1) 80%, rgba(255, 255, 255, 0.5) 90%, rgba(255, 255, 255, 0.8))',
-					width: '100%',
-					height: '100%',
-				}}
-			/>
-		</div>
-)
+  return (
+    <div
+      className={`${handles.HeadlessLoadingBar} fixed top-0 left-0 right-0 z-max bg-action-primary`}
+      style={{ height: 4 }}
+    >
+      <div
+        style={{
+          background:
+            'linear-gradient(90deg, rgba(255, 255, 255, 0.1) 80%, rgba(255, 255, 255, 0.5) 90%, rgba(255, 255, 255, 0.8))',
+          width: '100%',
+          height: '100%',
+        }}
+      />
+    </div>
+  );
 }
 
 export default HeadlessLoadingBar;

--- a/react/components/HeadlessLoadingBar.tsx
+++ b/react/components/HeadlessLoadingBar.tsx
@@ -1,0 +1,25 @@
+import { useCssHandles } from "vtex.css-handles";
+
+const CSS_HANDLES = ['HeadlessLoadingBar'] as const;
+
+const HeadlessLoadingBar = () => {
+const handles = useCssHandles(CSS_HANDLES);
+
+	return (
+		<div
+			className={`${handles.HeadlessLoadingBar} fixed top-0 left-0 right-0 z-max bg-action-primary`}
+			style={{ height: 4 }}
+		>
+			<div
+				style={{
+					background:
+					'background: linear-gradient(90deg, rgba(255, 255, 255, 0.1) 80%, rgba(255, 255, 255, 0.5) 90%, rgba(255, 255, 255, 0.8))',
+					width: '100%',
+					height: '100%',
+				}}
+			/>
+		</div>
+)
+}
+
+export default HeadlessLoadingBar;


### PR DESCRIPTION
### What problem is this solving?
https://www.notion.so/bashdotcom/PDP-Breadcrumb-Issues-f7a82f2d46e54848a72479a60e520267?pvs=4

Currently breadcrumbs from PDP navigate internally inside vtex io. 
I have converted these to anchor tags and added a loader as well that is the exact same as the current site loader 


### How it works:
Not Neccessary

#### How to test it?
https://webplp10--thefoschini.myvtex.com/men-s-aldo-cognac-dress-shoes-385000aamd5/p?property__Colour=Tan

Start at a PDP and click the breadrcumbs ensure a full page refresh is peformed and the PLP. you can see in the video below the console clears every navigation indicating a full page refresh 

### Screenshots/Video example usage:


https://github.com/TFG-Labs/breadcrumb/assets/29511241/d4e451f0-e828-422e-b8e6-924c059e5036



### Coding Standards Checklist: https://tfginfotec.atlassian.net/l/c/60ZyZonH
- [x] [BlockClass principles]( https://tfginfotec.atlassian.net/wiki/spaces/LABSPLAT/pages/1711341597/Styleguide+and+Code+Organisation+Principles#Block-Classes)
- [x] [Block name principles]( https://tfginfotec.atlassian.net/wiki/spaces/LABSPLAT/pages/1711341597/Styleguide+and+Code+Organisation+Principles#Block-Names?)
- [x] [Folder Structure principles ](https://tfginfotec.atlassian.net/wiki/spaces/LABSPLAT/pages/1711341597/Styleguide+and+Code+Organisation+Principles#JSON-Folder-Structure)
- [x] [CSS folder principles](https://tfginfotec.atlassian.net/wiki/spaces/LABSPLAT/pages/1711341597/Styleguide+and+Code+Organisation+Principles#CSS-Folder-Structure)
- [x] [JSONC files principles](https://tfginfotec.atlassian.net/wiki/spaces/LABSPLAT/pages/1711341597/Styleguide+and+Code+Organisation+Principles#JSONC-File-Structure)
- [x] [CSS file principles](https://tfginfotec.atlassian.net/wiki/spaces/LABSPLAT/pages/1711341597/Styleguide+and+Code+Organisation+Principles#CSS-file-structure)
- [x] S[tyle tokens and SCSS]( https://tfginfotec.atlassian.net/wiki/spaces/LABSPLAT/pages/1711341597/Styleguide+and+Code+Organisation+Principles#STYLE-TOKENS-AND-SCSS)
- [x [Code comments](https://tfginfotec.atlassian.net/wiki/spaces/LABSPLAT/pages/1711341597/Styleguide+and+Code+Organisation+Principles#STYLE-TOKENS-AND-SCSS)
- [x] [Responsibility to maintain code](https://tfginfotec.atlassian.net/wiki/spaces/LABSPLAT/pages/1711341597/Styleguide+and+Code+Organisation+Principles#Responsibility-to-Maintain-The-Code-Quality)

### How does this PR make you feel? 🔗